### PR TITLE
Update Rust dependencies

### DIFF
--- a/shims/shim/Cargo.lock
+++ b/shims/shim/Cargo.lock
@@ -1,42 +1,9 @@
 [[package]]
-name = "advapi32-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ktmw32-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "snafu"
 version = "0.1.0"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winreg 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winreg 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -48,31 +15,33 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "winapi-build"
-version = "0.1.1"
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winreg"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ktmw32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
-"checksum advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e06588080cb19d0acb6739808aafa5f26bfb2ca015b2b6370028b44cf7cb8a9a"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum ktmw32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3e7bd349909cb66100a2e177e5ad59fbcba0628f1a1b1f2e2e78d0ead03bbb05"
-"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
-"checksum winreg 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf285379f20d7f26abd990d9a566be9d31ab7a9d335299baaa1f0604f5f96af"
+"checksum winapi 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "890b38836c01d72fdb636d15c9cfc52ec7fd783b330abc93cd1686f4308dfccc"
+"checksum winapi-i686-pc-windows-gnu 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ca38ad0b1b8fcebdf9a7906e368ce3a760ffa638c4c4f0cb57f3c26ad34cc86e"
+"checksum winapi-x86_64-pc-windows-gnu 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a824ed89cff621305f4ae379551c65e1fca1eadb1d4a25e3a4e8989080a2d337"
+"checksum winreg 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9338067aba07889a38beaad4dbb77fa2e62e87c423b770824b3bdf412874bd2c"

--- a/shims/snafu/Cargo.lock
+++ b/shims/snafu/Cargo.lock
@@ -1,71 +1,40 @@
 [[package]]
-name = "advapi32-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ktmw32-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "snafu"
 version = "0.1.0"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winreg 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winreg 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "winapi-build"
-version = "0.1.1"
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winreg"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ktmw32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
-"checksum advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e06588080cb19d0acb6739808aafa5f26bfb2ca015b2b6370028b44cf7cb8a9a"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum ktmw32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3e7bd349909cb66100a2e177e5ad59fbcba0628f1a1b1f2e2e78d0ead03bbb05"
-"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
-"checksum winreg 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf285379f20d7f26abd990d9a566be9d31ab7a9d335299baaa1f0604f5f96af"
+"checksum winapi 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "890b38836c01d72fdb636d15c9cfc52ec7fd783b330abc93cd1686f4308dfccc"
+"checksum winapi-i686-pc-windows-gnu 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ca38ad0b1b8fcebdf9a7906e368ce3a760ffa638c4c4f0cb57f3c26ad34cc86e"
+"checksum winapi-x86_64-pc-windows-gnu 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a824ed89cff621305f4ae379551c65e1fca1eadb1d4a25e3a4e8989080a2d337"
+"checksum winreg 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9338067aba07889a38beaad4dbb77fa2e62e87c423b770824b3bdf412874bd2c"

--- a/shims/snafu/Cargo.toml
+++ b/shims/snafu/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 authors = ["Tzu-ping Chung <uranusjr@gmail.com>"]
 
 [dependencies]
-kernel32-sys = "0.2.2"
-winapi = "0.2.8"
-winreg = "0.4"
+winapi = { version = "0.3.2", features = ["consoleapi", "jobapi2", "wincon"] }
+winreg = "0.5.0"
 
 [[bin]]
 name = "snafu"

--- a/shims/snafu/src/procs.rs
+++ b/shims/snafu/src/procs.rs
@@ -1,4 +1,3 @@
-extern crate kernel32;
 extern crate winapi;
 
 use std::{env, mem};
@@ -6,8 +5,17 @@ use std::os::windows::io::AsRawHandle;
 use std::path::PathBuf;
 use std::process::{Child, Command, abort, exit};
 
-use self::kernel32::*;
-use self::winapi::*;
+use self::winapi::ctypes::c_void;
+use self::winapi::shared::minwindef::{BOOL, DWORD, LPVOID, TRUE};
+use self::winapi::um::consoleapi::SetConsoleCtrlHandler;
+use self::winapi::um::jobapi2::{
+    AssignProcessToJobObject, CreateJobObjectW, QueryInformationJobObject,
+    SetInformationJobObject};
+use self::winapi::um::wincon::{CTRL_C_EVENT, GenerateConsoleCtrlEvent};
+use self::winapi::um::winnt::{
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK,
+    JobObjectExtendedLimitInformation};
 
 
 static mut PID: u32 = 0;
@@ -50,7 +58,7 @@ unsafe fn setup_child(child: &mut Child) -> Result<(), &'static str> {
         return Err("job information set error");
     }
 
-    AssignProcessToJobObject(job, child.as_raw_handle());
+    AssignProcessToJobObject(job, child.as_raw_handle() as *mut c_void);
 
     Ok(())
 }

--- a/shims/snafu/src/procs.rs
+++ b/shims/snafu/src/procs.rs
@@ -99,12 +99,10 @@ pub fn run_and_end(exe: PathBuf, args: Vec<&str>, own_args: bool) {
 }
 
 pub fn setup() -> Result<(), &'static str> {
-    unsafe {
-        let ok = SetConsoleCtrlHandler(Some(handle_ctrl), TRUE);
-        if ok == TRUE {
-            Ok(())
-        } else {
-            Err("control handler set error")
-        }
+    let ok = unsafe { SetConsoleCtrlHandler(Some(handle_ctrl), TRUE) };
+    if ok == TRUE {
+        Ok(())
+    } else {
+        Err("control handler set error")
     }
 }

--- a/shims/snafu/src/pythons.rs
+++ b/shims/snafu/src/pythons.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use super::tags::Tag;
 
 use self::winreg::RegKey;
-use self::winreg::enums::{HKEY_CURRENT_USER, KEY_READ};
+use self::winreg::enums::HKEY_CURRENT_USER;
 
 
 fn get(tag: &Tag) -> Result<PathBuf, String> {
@@ -14,12 +14,10 @@ fn get(tag: &Tag) -> Result<PathBuf, String> {
         .join(tag.to_string()).join("InstallPath");
 
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
-    let key = try! {
-        hkcu.open_subkey_with_flags(&key_path, KEY_READ).map_err(|e| {
-            let key_path_string = key_path.to_string_lossy();
-            format!("failed to open {}: {}", key_path_string, e)
-        })
-    };
+    let key = try!(hkcu.open_subkey(&key_path).map_err(|e| {
+        let key_path_string = key_path.to_string_lossy();
+        format!("failed to open {}: {}", key_path_string, e)
+    }));
 
     let value: String = try! {
         key.get_value("").map_err(|e| {
@@ -35,7 +33,7 @@ fn find_installed() -> BTreeSet<Tag> {
 
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
     let key_path_str = "Software\\Python\\PythonCore";
-    let key = match hkcu.open_subkey_with_flags(key_path_str, KEY_READ) {
+    let key = match hkcu.open_subkey(key_path_str) {
         Ok(key) => key,
         Err(e) => {
             eprintln!("failed to read {}: {}", key_path_str, e);
@@ -71,11 +69,9 @@ pub fn find_best_using(tag: &Tag) -> Result<PathBuf, String> {
     let key_path_str = "Software\\uranusjr\\SNAFU";
 
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
-    let key = try! {
-        hkcu.open_subkey_with_flags(&key_path_str, KEY_READ).map_err(|e| {
-            format!("failed to open {}: {}", key_path_str, e)
-        })
-    };
+    let key = try!(hkcu.open_subkey(&key_path_str).map_err(|e| {
+        format!("failed to open {}: {}", key_path_str, e)
+    }));
     let value: String = try! {
         key.get_value("ActivePythonVersions").map_err(|e| e.to_string())
     };
@@ -99,11 +95,9 @@ pub fn find_of_snafu() -> Result<PathBuf, String> {
     let key_path = "Software\\uranusjr\\SNAFU";
 
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
-    let key = try! {
-        hkcu.open_subkey_with_flags(key_path, KEY_READ).map_err(|e| {
-            format!("failed to open {}: {}", key_path, e)
-        })
-    };
+    let key = try!(hkcu.open_subkey(key_path).map_err(|e| {
+        format!("failed to open {}: {}", key_path, e)
+    }));
 
     let value: String = try! {
         key.get_value("InstallPath").map_err(|e| {


### PR DESCRIPTION
This will be merged after 2.0 is out.

### winreg → 0.5.0

The default permission is now read-only, which allows the code to be cleaned up a little.

### winapi → 0.3.2

The 0.3 upgrade breaks some API. I now need to explicit cast raw handler to * winapi::ctypes::c_void, (which makes me a bit unconfortable), and need to specify and use indivisual features now. Surprisingly this does not reduce the built size in any slight bit. What the hell.